### PR TITLE
[update]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 1.0.1.0
+
+### update
+
+* 支持jdk版本 1.8及以上版本，不再支持jdk1.6
+* 重试支持切换域名
+* 支持设置接口维度的超时时间
+* 修改默认的连接超时时间，60s改为10s
+* 内部异常，会拼接到apiResult的msg上，eg. 原来接口超时返回`{"code":5000, "message":"http error::5000"}`，修改后返回`{"code":5000, "message":"http error:Read timed out::5000"}
+
 ## 1.0.0.17
 
 ### update

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 
 ## 环境要求
-1. 需要配合`JDK 1.6`或其以上版本。
+1. 需要配合`JDK 1.8`或其以上版本。
 
 2. 使用`个推PUSH SDK`前，您需要先前往[个推开发者中心](https://dev.getui.com) 完成开发者接入的一些准备工作，创建应用。详细见[操作步骤](https://docs.getui.com/getui/start/devcenter/#1)
 
@@ -22,7 +22,7 @@
 <dependency>
     <groupId>com.getui.push</groupId>
     <artifactId>restful-sdk</artifactId>
-    <version>1.0.0.17</version>
+    <version>1.0.1.0</version>
 </dependency>
 ```
 
@@ -46,7 +46,7 @@ public class TestCreatApi {
         apiConfiguration.setAppId("xxx");
         apiConfiguration.setAppKey("xxx");
         apiConfiguration.setMasterSecret("xxx");
-        // 接口调用前缀，请查看文档: 接口调用规范 -> 接口前缀, 可不填写appId
+        // 接口调用前缀，请查看文档: 接口调用规范 -> 接口前缀
         apiConfiguration.setDomain("https://restapi.getui.com/v2/");
         // 实例化ApiHelper对象，用于创建接口对象
         ApiHelper apiHelper = ApiHelper.build(apiConfiguration);
@@ -55,6 +55,24 @@ public class TestCreatApi {
     }
 }
 ```
+
+###### 已支持的配置项说明
+| 通过代码修改 | 启动项 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| gtApiConfiguration.setSoTimeout(30000); | \-Dgt.socket.timeout=30000 | 30000 | 修改全局的套接字读超时时间，默认30s，单位ms |
+| gtApiConfiguration.setCustomSocketTimeout(PushApi.singleCidUri, 3000); | \-D/push/single/cid= | 默认为gt.socket.timeout的值 | cid单推接口设置套接字读取超时时间，单位ms |
+| gtApiConfiguration.setCustomSocketTimeout(PushApi.singleAliasUri, 3000); | \-D/push/single/alias= | 默认为gt.socket.timeout的值 | 别名单推接口设置套接字读取超时时间，单位ms |
+| gtApiConfiguration.setCustomSocketTimeout(PushApi.singleBatchCidUri, 6000); | \-D/push/single/batch/cid= | 默认为gt.socket.timeout的值 | cid批量单推接口设置套接字读取超时时间，单位ms |
+| gtApiConfiguration.setCustomSocketTimeout(PushApi.singleBatchAliasUri, 6000); | \-D/push/single/batch/alias= | 默认为gt.socket.timeout的值 | 别名批量单推接口设置套接字读取超时时间，单位ms |
+| gtApiConfiguration.setCustomSocketTimeout(PushApi.pushListMessageUri, 3000); | \-D/push/list/message= | 默认为gt.socket.timeout的值 | 保存列表推消息体接口设置套接字读取超时时间，单位ms |
+| gtApiConfiguration.setCustomSocketTimeout(PushApi.pushListCidUri, 6000); | \-D/push/list/cid= | 默认为gt.socket.timeout的值 | cid列表推接口设置套接字读取超时时间，单位ms |
+| gtApiConfiguration.setCustomSocketTimeout(PushApi.pushListAliasUri, 6000); | \-D/push/list/alias= | 默认为gt.socket.timeout的值 | 别名列表推接口设置套接字读取超时时间，单位ms |
+| gtApiConfiguration.setConnectTimeout(10000); | \-Dgt.connect.timeout=10000 | 10000 | 修改连接超时时间，默认10s，单位ms |
+| gtApiConfiguration.setMaxHttpTryTime(1); | \-Dgt.max.http.try.times=1 | 1 |设置重试次数；<br>上述配置项设为1时，如果请求失败(超时或其他异常)，sdk内部会重试1次，重试可能造成消息重复，建议客户配合消息幂等使用，详见文档：[消息覆盖https://docs.getui.com/getui/server/rest_v2/advanced/](https://docs.getui.com/getui/server/rest_v2/advanced/)；<br>用户不接受重试的，可将此值改为0|
+| gtApiConfiguration.setOpenAnalyseStableDomainSwitch(true); | \-Dgt.analyse.stable.domain.switch=true | true | 是否开启稳定域名检测 |
+| gtApiConfiguration.setMaxFailedNum(10); | \-Dgt.max.failed.num=10 | 10 | 开启稳定域名检测时生效，单位时间内失败总次数阈值，达到阈值会切换域名 |
+| gtApiConfiguration.setCheckMaxFailedNumInterval(3000); | \-Dgt.check.max.failed.num.interval=3000 | 3000 | 开启稳定域名检测时生效，修改上述阈值的单位时间，单位ms |
+| gtApiConfiguration.setContinuousFailedNum(3); | \-Dgt.continuous.failed.num=3 | 3 | 开启稳定域名检测时生效，连续失败次数达到阈值会切换域名 |
 
 ##### 使用示例：**推送API**_根据cid进行单推
 
@@ -176,7 +194,7 @@ public class TestUserApi {
 ### 设置代理
 > 当需要使用代理进行http访问时，可以参考如下设置
 
-```java
+```
         GtApiConfiguration apiConfiguration = new GtApiConfiguration();
         //设置代理对象，参数依次为host、端口、鉴权账户、鉴权密码。其中鉴权账户密码可选
         GtHttpProxyConfig proxyConfig = new GtHttpProxyConfig("xxx",xxx,"xxx","xxx");

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.getui.push</groupId>
     <artifactId>restful-sdk</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0.17</version>
+    <version>1.0.1.0</version>
     <url>https://github.com/GetuiLaboratory/getui-pushapi-java-client-v2</url>
     <name>Getui Push API Java Client</name>
     <description>Getui's officially supported Java client library for accessing Getui APIs.</description>
@@ -80,7 +80,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.8.2</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>
@@ -91,8 +91,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <encoding>utf-8</encoding>
                 </configuration>
             </plugin>

--- a/src/main/java/com/getui/push/v2/sdk/ApiHelper.java
+++ b/src/main/java/com/getui/push/v2/sdk/ApiHelper.java
@@ -7,6 +7,7 @@ import com.getui.push.v2.sdk.common.Assert;
 import com.getui.push.v2.sdk.core.DefaultJson;
 import com.getui.push.v2.sdk.core.client.DefaultApiClient;
 import com.getui.push.v2.sdk.core.factory.GtApiProxyFactory;
+import com.getui.push.v2.sdk.core.handler.GtInterceptor;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,6 +38,14 @@ public class ApiHelper {
      * @return
      */
     public static ApiHelper build(GtApiConfiguration configuration, IJson json) {
+        return build(configuration, json, null);
+    }
+
+    /**
+     * @param configuration 配置信息类
+     * @return
+     */
+    public static ApiHelper build(GtApiConfiguration configuration, IJson json, GtInterceptor interceptor) {
         Assert.notNull(configuration, "configuration");
         configuration.check();
         String key = configuration.keyOfCache();
@@ -53,6 +62,9 @@ public class ApiHelper {
                 return apiHelper;
             }
             final DefaultApiClient defaultApiClient = DefaultApiClient.build(configuration, json);
+            if (interceptor != null) {
+                defaultApiClient.addGtInterceptor(interceptor);
+            }
             GtApiProxyFactory factory = GtApiProxyFactory.build(defaultApiClient);
             final AuthApi authApi = factory.createProxy(AuthApi.class);
             defaultApiClient.setAuthApiAndAuth(authApi);

--- a/src/main/java/com/getui/push/v2/sdk/api/PushApi.java
+++ b/src/main/java/com/getui/push/v2/sdk/api/PushApi.java
@@ -22,13 +22,21 @@ import java.util.Map;
  */
 public interface PushApi {
 
+    String singleCidUri = "/push/single/cid";
+    String singleAliasUri = "/push/single/alias";
+    String singleBatchCidUri = "/push/single/batch/cid";
+    String singleBatchAliasUri = "/push/single/batch/alias";
+    String pushListMessageUri = "/push/list/message";
+    String pushListCidUri = "/push/list/cid";
+    String pushListAliasUri = "/push/list/alias";
+
     /**
      * 根据cid推送
      *
      * @param pushDTO
      * @return k: cid, v: status
      */
-    @GtPost(uri = "/push/single/cid")
+    @GtPost(uri = singleCidUri)
     ApiResult<Map<String, Map<String, String>>> pushToSingleByCid(@GtBodyParam PushDTO<Audience> pushDTO);
 
     /**
@@ -37,7 +45,7 @@ public interface PushApi {
      * @param pushDTO
      * @return
      */
-    @GtPost(uri = "/push/single/alias")
+    @GtPost(uri = singleAliasUri)
     ApiResult<Map<String, Map<String, String>>> pushToSingleByAlias(@GtBodyParam PushDTO<Audience> pushDTO);
 
     /**
@@ -46,7 +54,7 @@ public interface PushApi {
      * @param pushBatchDTO
      * @return
      */
-    @GtPost(uri = "/push/single/batch/cid")
+    @GtPost(uri = singleBatchCidUri)
     ApiResult<Map<String, Map<String, String>>> pushBatchByCid(@GtBodyParam PushBatchDTO pushBatchDTO);
 
     /**
@@ -55,7 +63,7 @@ public interface PushApi {
      * @param pushBatchDTO
      * @return
      */
-    @GtPost(uri = "/push/single/batch/alias")
+    @GtPost(uri = singleBatchAliasUri)
     ApiResult<Map<String, Map<String, String>>> pushBatchByAlias(@GtBodyParam PushBatchDTO pushBatchDTO);
 
     /**
@@ -64,7 +72,7 @@ public interface PushApi {
      * @param pushDTO
      * @return
      */
-    @GtPost(uri = "/push/list/message")
+    @GtPost(uri = pushListMessageUri)
     ApiResult<TaskIdDTO> createMsg(@GtBodyParam PushDTO pushDTO);
 
     /**
@@ -73,7 +81,7 @@ public interface PushApi {
      * @param audienceDTO
      * @return
      */
-    @GtPost(uri = "/push/list/cid")
+    @GtPost(uri = pushListCidUri)
     ApiResult<Map<String, Map<String, String>>> pushListByCid(@GtBodyParam AudienceDTO audienceDTO);
 
     /**
@@ -82,7 +90,7 @@ public interface PushApi {
      * @param audienceDTO
      * @return
      */
-    @GtPost(uri = "/push/list/alias")
+    @GtPost(uri = pushListAliasUri)
     ApiResult<Map<String, Map<String, String>>> pushListByAlias(@GtBodyParam AudienceDTO audienceDTO);
 
     /**

--- a/src/main/java/com/getui/push/v2/sdk/common/http/HttpManager.java
+++ b/src/main/java/com/getui/push/v2/sdk/common/http/HttpManager.java
@@ -1,7 +1,9 @@
 package com.getui.push.v2.sdk.common.http;
 
+import com.getui.push.v2.sdk.GtApiConfiguration;
 import com.getui.push.v2.sdk.GtHttpProxyConfig;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -27,6 +29,21 @@ public class HttpManager {
     }
 
     public String syncHttps(String url, String method, Map<String, Object> headers, String body, String contentType) {
-        return client.execute(url, method, headers, body, contentType);
+        return syncHttps(url, null, 0, method, headers, body, contentType);
     }
+
+    /**
+     * @param url
+     * @param rasDomain     天上的域名，失败重试时，会修改域名。空或null时失败重试不切换域名
+     * @param socketTimeout 接口超时时间，0表示默认，默认值为{@link GtApiConfiguration#getSoTimeout()}
+     * @param method
+     * @param headers
+     * @param body
+     * @param contentType
+     * @return
+     */
+    public String syncHttps(String url, List<String> rasDomain, int socketTimeout, String method, Map<String, Object> headers, String body, String contentType) {
+        return client.execute(url, rasDomain, socketTimeout, method, headers, body, contentType);
+    }
+
 }

--- a/src/main/java/com/getui/push/v2/sdk/common/util/Utils.java
+++ b/src/main/java/com/getui/push/v2/sdk/common/util/Utils.java
@@ -61,4 +61,21 @@ public final class Utils {
         return true;
     }
 
+    static final String v2UrlPrefix = "/v2";
+
+    /**
+     * 对于v2的接口，一定存在/v2前缀
+     *
+     * @param url
+     * @return
+     */
+    public static String v2UrlToHost(String url) {
+        int v2Index = url.indexOf(v2UrlPrefix);
+        if (v2Index > 0) {
+            return url.substring(0, v2Index);
+        } else {
+            return url;
+        }
+    }
+
 }

--- a/src/main/java/com/getui/push/v2/sdk/core/Configs.java
+++ b/src/main/java/com/getui/push/v2/sdk/core/Configs.java
@@ -13,7 +13,7 @@ public interface Configs {
 
     String HEADER_DOMAIN_HASH_KEY = "domainHash";
     String HEADER_OPEN_STABLE_DOMAIN = "openStableDomain";
-    String SDK_VERSION = "1.0.0.17";
+    String SDK_VERSION = "1.0.1.0";
     /**
      * 预置域名列表
      */

--- a/src/main/java/com/getui/push/v2/sdk/core/handler/GtInterceptor.java
+++ b/src/main/java/com/getui/push/v2/sdk/core/handler/GtInterceptor.java
@@ -33,20 +33,22 @@ public interface GtInterceptor {
     /**
      * 报错时调用此方法
      *
+     * @param host     当前使用的host
      * @param apiParam 请求参数
      * @param header   请求header
      * @param body     请求body
      * @param e        异常信息
      */
-    void handleException(GtApiProxyFactory.ApiParam apiParam, Map<String, Object> header, String body, ApiException e);
+    void handleException(String host, GtApiProxyFactory.ApiParam apiParam, Map<String, Object> header, String body, ApiException e);
 
     /**
      * http请求后调用，不管成功或者失败都会调用
      *
+     * @param host     当前使用的host
      * @param apiParam 请求参数
      * @param header   请求header
      * @param body     请求body
      * @param result   返回值
      */
-    void afterCompletion(GtApiProxyFactory.ApiParam apiParam, Map<String, Object> header, String body, String result);
+    void afterCompletion(String host, GtApiProxyFactory.ApiParam apiParam, Map<String, Object> header, String body, String result);
 }

--- a/src/main/java/com/getui/push/v2/sdk/core/handler/impl/DefaultGtInterceptor.java
+++ b/src/main/java/com/getui/push/v2/sdk/core/handler/impl/DefaultGtInterceptor.java
@@ -2,7 +2,7 @@ package com.getui.push.v2.sdk.core.handler.impl;
 
 import com.getui.push.v2.sdk.GtApiConfiguration;
 import com.getui.push.v2.sdk.common.ApiException;
-import com.getui.push.v2.sdk.core.Configs;
+import com.getui.push.v2.sdk.common.Monitor;
 import com.getui.push.v2.sdk.core.factory.GtApiProxyFactory;
 import com.getui.push.v2.sdk.core.handler.GtInterceptor;
 import com.getui.push.v2.sdk.core.manager.HostManager;
@@ -16,6 +16,8 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * create by getui on 2020/9/28
@@ -25,7 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class DefaultGtInterceptor implements GtInterceptor {
 
     private Logger log = LoggerFactory.getLogger(this.getClass());
-    private static final ThreadLocal<Long> START_TIME = new ThreadLocal<Long>();
+    private static final ThreadLocal<Long> START_TIME = new ThreadLocal<>();
 
     private final ConcurrentMap<String, StateWrapper> stateWrapperMap = new ConcurrentHashMap<String, StateWrapper>();
 
@@ -35,10 +37,18 @@ public class DefaultGtInterceptor implements GtInterceptor {
     private final BlockingQueue<StateWrapper> reportDataQueue;
     private final GtApiConfiguration configuration;
 
+    /**
+     * 域名切换时加锁，防止短时间内重复切换
+     */
+    final Lock switchLock = new ReentrantLock();
+
     public DefaultGtInterceptor(HostManager hostManager, BlockingQueue<StateWrapper> reportDataQueue, GtApiConfiguration configuration) {
         this.hostManager = hostManager;
         this.reportDataQueue = reportDataQueue;
         this.configuration = configuration;
+        if (configuration.isOpenAnalyseStableDomainSwitch()) {
+            Monitor.init(configuration.getCheckMaxFailedNumInterval());
+        }
     }
 
     @Override
@@ -53,36 +63,57 @@ public class DefaultGtInterceptor implements GtInterceptor {
     }
 
     @Override
-    public void handleException(GtApiProxyFactory.ApiParam apiParam, Map<String, Object> header, String body, ApiException e) {
+    public void handleException(String host, GtApiProxyFactory.ApiParam apiParam, Map<String, Object> header, String body, ApiException e) {
         log.error("http error. param: {}, body: {}.", apiParam, body, e);
         if (configuration.isOpenCheckHealthDataSwitch()) {
             ServiceState serviceState = get(hostManager.getUsing()).get(apiParam.getUri());
             serviceState.incrFailedTimes();
         }
-        if (failNum.incrementAndGet() > Configs.MAX_FAIL_CONTINUOUSLY) {
-            log.debug("The num of failures are frequent.");
-            failNum.set(0);
-            if (configuration.isOpenCheckHealthDataSwitch()) {
-                this.reportDataQueue.offer(getAndRemove(hostManager.getUsing()));
-            }
-            if (configuration.isOpenAnalyseStableDomainSwitch()) {
-                // 切换域名
-                hostManager.switchHost();
-            }
+        // 连续失败次数达到阈值
+        int num = failNum.incrementAndGet();
+        if (num > configuration.getContinuousFailedNum()) {
+            resetAndSwitchHost(host, "continuous", num);
         }
     }
 
     @Override
-    public void afterCompletion(GtApiProxyFactory.ApiParam apiParam, Map<String, Object> header, String body, String result) {
+    public void afterCompletion(String host, GtApiProxyFactory.ApiParam apiParam, Map<String, Object> header, String body, String result) {
         try {
             if (configuration.isOpenCheckHealthDataSwitch()) {
                 long cost = System.currentTimeMillis() - START_TIME.get();
-                final ServiceState serviceState = get(hostManager.getUsing()).get(apiParam.getUri());
+                final ServiceState serviceState = get(host).get(apiParam.getUri());
                 serviceState.addCallTime(cost);
                 serviceState.incrCallTimes();
             }
+            // 单位时间内失败次数达到阈值，切换域名
+            long failedTotal = Monitor.get(host);
+            if (failedTotal > configuration.getMaxFailedNum()) {
+                resetAndSwitchHost(host, "total", failedTotal);
+            }
         } finally {
             START_TIME.remove();
+        }
+    }
+
+    void resetAndSwitchHost(String host, String reason, long failedNum) {
+        boolean locked = switchLock.tryLock();
+        if (!locked) {
+            return;
+        }
+        try {
+            // 失败次数重置
+            Monitor.reset(host);
+            failNum.set(0);
+            if (configuration.isOpenCheckHealthDataSwitch()) {
+                this.reportDataQueue.offer(getAndRemove(host));
+            }
+            if (configuration.isOpenAnalyseStableDomainSwitch()) {
+                log.debug("The number of failures has reached the threshold, will switch host. reason:{}, failedNum:{}", reason, failedNum);
+                // 切换域名
+                hostManager.switchHost(host);
+            }
+        } finally {
+            switchLock.unlock();
         }
     }
 

--- a/src/main/java/com/getui/push/v2/sdk/core/manager/HostManager.java
+++ b/src/main/java/com/getui/push/v2/sdk/core/manager/HostManager.java
@@ -11,6 +11,8 @@ import com.getui.push.v2.sdk.core.domain.RasDomainBO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -26,6 +28,8 @@ public class HostManager {
 
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    volatile ThreadPoolExecutor analyseStableDomainExecutor;
+
     public HostManager(GtApiConfiguration configuration, HttpManager httpManager) {
         this.configuration = configuration;
         this.using = configuration.getDomain();
@@ -39,7 +43,7 @@ public class HostManager {
     /**
      * 正在使用的域名
      */
-    private String using;
+    private volatile String using;
     /**
      * 切换域名的锁
      */
@@ -48,15 +52,18 @@ public class HostManager {
     /**
      * 天上拉下来的域名
      */
-    private RasDomainBO rasDomain;
+    private volatile RasDomainBO rasDomain;
     private final Object setRasDomainLock = new Object();
 
-    private List<String> sortedDomains;
+    /**
+     * {@link #rasDomain} 经过优先级算法排序后的结果
+     */
+    private volatile List<String> sortedDomains;
 
     /**
      * 域名优先级队列
      */
-    private BlockingQueue<String> sortedHostQueue;
+    private volatile BlockingQueue<String> sortedHostQueue;
 
     /**
      * 增量，域名切换次数
@@ -81,10 +88,16 @@ public class HostManager {
             return;
         }
         if (setRasDomainBO(domainBO)) {
+            // 清空已有域名，确保域名队列中天上域名在最前面(本地域名可能存在跨机房等问题)
             if (!Utils.isEmpty(sortedDomains)) {
                 sortedDomains.clear();
             }
             resetHostQueue();
+            if (Utils.isEmpty(domainBO.getHostList().get(0).getDomainList())) {
+                logger.warn("domain list is empty, please check");
+                return;
+            }
+            // 不确定是域名改变还是跨机房，所以必须切域名(如果天上域名不可用，重试会换域名)
             switchTo(domainBO.getHostList().get(0).getDomainList().get(0));
         }
     }
@@ -92,7 +105,7 @@ public class HostManager {
     /**
      * @param willUse
      */
-    public void switchTo(String willUse) {
+    private void switchTo(String willUse) {
         if (Utils.isNotEmpty(willUse) && willUse.equals(this.using)) {
             return;
         }
@@ -100,6 +113,19 @@ public class HostManager {
         switchIncr.incrementAndGet();
         switchTotal.incrementAndGet();
         this.using = willUse;
+    }
+
+    /**
+     * 切换域名
+     *
+     * @param oldHost 上次使用的域名
+     */
+    public void switchHost(String oldHost) {
+        if (oldHost != null && !oldHost.equalsIgnoreCase(using)) {
+            // 表示已切换
+            return;
+        }
+        switchHost();
     }
 
     /**
@@ -135,10 +161,31 @@ public class HostManager {
         resetHostQueueHard();
     }
 
+    /**
+     * 获取天上的域名列表
+     *
+     * @return
+     */
+    public List<String> getCustomizedDomains() {
+        RasDomainBO rasDomain = this.rasDomain;
+        if (rasDomain == null || rasDomain.getHostList() == null) {
+            return Collections.emptyList();
+        }
+        List<String> domains = new ArrayList<String>();
+        for (DomainListBO domainListBO : rasDomain.getHostList()) {
+            if (domainListBO == null || domainListBO.getDomainList() == null) {
+                continue;
+            }
+            domains.addAll(domainListBO.getDomainList());
+        }
+        return domains;
+    }
+
     private void resetHostQueueHard() {
         RasDomainBO rasDomain = this.rasDomain;
         BlockingQueue<String> queue = new LinkedBlockingDeque<String>();
         if (Utils.isEmpty(sortedDomains)) {
+            // 优先使用天上的域名，如果跨机房，客户设置的域名就会有问题
             if (rasDomain != null &&
                     Utils.isNotEmpty(rasDomain.getHostList())) {
                 for (DomainListBO domainListBO : rasDomain.getHostList()) {
@@ -203,21 +250,31 @@ public class HostManager {
             logger.debug("Analysing stopped because the hostList is empty.");
             return;
         }
+        if (analyseStableDomainExecutor == null) {
+            analyseStableDomainExecutor = new ThreadPoolExecutor(4, 4, 1, TimeUnit.HOURS, new LinkedBlockingQueue<Runnable>(10), new ThreadFactory() {
+                private final AtomicInteger threadNumber = new AtomicInteger(1);
+                private final String namePrefix = "analyseStableDomain-";
+
+                @Override
+                public Thread newThread(Runnable r) {
+                    Thread t = new Thread(r, namePrefix + threadNumber.getAndIncrement());
+                    t.setDaemon(true);
+                    return t;
+                }
+            }, new ThreadPoolExecutor.DiscardPolicy());
+        }
         final List<String> sortedHost = new DomainCheck(new IDomainCheck() {
             @Override
             public boolean check(final String url) {
-                FutureTask<Boolean> task = new FutureTask(new Callable() {
-                    @Override
-                    public Object call() throws Exception {
-                        httpManager.syncHttps(url + "/v2/check", "head", null, null, null);
-                        return true;
-                    }
+                int socketTimeout = configuration.getHttpCheckTimeout();
+                Future<Boolean> future = analyseStableDomainExecutor.submit(() -> {
+                    httpManager.syncHttps(url + "/v2/check", null, socketTimeout, "head", null, null, null);
+                    return true;
                 });
-                new Thread(task).start();
                 try {
-                    return task.get(1, TimeUnit.SECONDS);
+                    return future.get(socketTimeout, TimeUnit.MILLISECONDS);
                 } catch (TimeoutException e) {
-                    task.cancel(true);
+                    future.cancel(true);
                 } catch (Exception e) {
                 }
                 return false;
@@ -226,7 +283,7 @@ public class HostManager {
         if (Utils.isNotEmpty(sortedHost)) {
             this.sortedDomains = sortedHost;
         }
-        logger.debug("analyseStableDomain finished. result: {}.", sortedHost);
+        logger.debug("analyseStableDomain finished. domains: {}, result: {}.", rasDomain.getHostList(), sortedHost);
         resetHostQueueHard();
         switchHost();
     }

--- a/src/main/java/com/getui/push/v2/sdk/dto/CommonEnum.java
+++ b/src/main/java/com/getui/push/v2/sdk/dto/CommonEnum.java
@@ -58,7 +58,7 @@ public interface CommonEnum {
 
         @Override
         public Integer get() {
-            return null;
+            return level;
         }
 
         ChannelLevelEnum(int level, String msg) {


### PR DESCRIPTION
  1. 支持jdk 1.8及以上版本，不再支持jdk1.6
  2. 重试支持切换域名
  3. 支持设置接口维度的超时时间
  4. 修改默认的连接超时时间，30s改为10s
  5. 内部异常，会拼接到apiResult的msg上，eg. 原来接口超时返回`{"code":5000, "message":"http error::5000"}`，修改后返回`{"code":5000, "message":"http error:Read timed out::5000"}